### PR TITLE
Update sync-repo-settings.yaml

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,14 +10,6 @@ squashMergeAllowed: true
 # Defaults to `false`
 mergeCommitAllowed: false
 
-# Rules for master branch protection
-branchProtectionRules:
-# Identifies the protection rule pattern. Name of the branch to be protected.
-# Defaults to `master`
-- pattern: master
-  # Is pushing to matching branches restricted.
-  restrictsPushes: false
-
 # List of explicit permissions to add (additive only)
 permissionRules:
 - team: yoshi-admins


### PR DESCRIPTION
Removed `branchProtectionRules`. I think the bot will stop updating the branch protection rule.